### PR TITLE
Proper publishing setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,6 @@ jobs:
           path: bootstrap/build/libs/PackConverter.jar
           if-no-files-found: error
 
-      - name: Archive artifacts (Converter)
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-        if: success()
-        with:
-          name: PackConverter Library
-          path: converter/build/libs/PackConverter-lib.jar
-          if-no-files-found: error
-
       - name: Publish to Maven Repository
         if: ${{ success() && github.repository == 'GeyserMC/PackConverter' && github.ref_name == 'master' }}
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5

--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -21,6 +21,6 @@ application {
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-    archiveFileName.set("PackConverter-Standalone.jar")
-    archiveClassifier.set("")
+    archiveClassifier.set("all")
+    archiveFileName.set("PackConverter.jar")
 }

--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     `java-library`
     application
-    id("com.github.johnrengelman.shadow") version "7.1.0"
+    id("com.github.johnrengelman.shadow") apply true
 }
 
 sourceSets {
@@ -21,6 +21,5 @@ application {
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-    archiveClassifier.set("all")
     archiveFileName.set("PackConverter.jar")
 }

--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
-    id("application")
+    `java-library`
+    application
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir("src/main/java/resources")
+        }
+    }
 }
 
 dependencies {
@@ -11,10 +21,6 @@ application {
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-    from("src/main/java/resources") {
-        include("*")
-    }
-
-    archiveFileName.set("PackConverter.jar")
+    archiveFileName.set("PackConverter-Standalone.jar")
     archiveClassifier.set("")
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,9 +3,10 @@ plugins {
 }
 
 dependencies {
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:8.1.1")
+    implementation("com.github.johnrengelman:shadow:8.1.1")
 }
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,7 +2,10 @@ plugins {
     `kotlin-dsl`
 }
 
+dependencies {
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:8.1.1")
+}
+
 repositories {
-    gradlePluginPortal()
     mavenCentral()
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/pack.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/pack.base-conventions.gradle.kts
@@ -1,0 +1,5 @@
+import org.gradle.kotlin.dsl.`java-library`
+
+plugins {
+    `java-library`
+}

--- a/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    `maven-publish`
-    id("com.github.johnrengelman.shadow") apply false
+    `maven-publish` apply true
+    id("com.github.johnrengelman.shadow")
 }
 
 publishing {

--- a/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `maven-publish` apply true
-    id("com.github.johnrengelman.shadow")
+    id("com.github.johnrengelman.shadow") apply false
 }
 
 publishing {

--- a/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `maven-publish`
+}
+
+publishing {
+    repositories {
+        val repoName = if (version.toString().endsWith("SNAPSHOT")) "maven-snapshots" else "maven-releases"
+        maven("https://repo.opencollab.dev/${repoName}/") {
+            credentials.username = System.getenv("OPENCOLLAB_USERNAME")
+            credentials.password = System.getenv("OPENCOLLAB_PASSWORD")
+            name = "opencollab"
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/pack.publish-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `maven-publish`
+    id("com.github.johnrengelman.shadow") apply false
 }
 
 publishing {
@@ -9,6 +10,16 @@ publishing {
             credentials.username = System.getenv("OPENCOLLAB_USERNAME")
             credentials.password = System.getenv("OPENCOLLAB_PASSWORD")
             name = "opencollab"
+        }
+    }
+
+    publications {
+        register("publish", MavenPublication::class) {
+            from(project.components["java"])
+
+            // skip shadow jar from publishing. Workaround for https://github.com/johnrengelman/shadow/issues/651
+            val javaComponent = project.components["java"] as AdhocComponentWithVariants
+            javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) { skip() }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("pack.base-conventions")
-    id("pack.publish-conventions")
 }
 
 subprojects{
@@ -11,12 +10,4 @@ subprojects{
 
     java.sourceCompatibility = JavaVersion.VERSION_17
     java.targetCompatibility = JavaVersion.VERSION_17
-
-    publishing {
-        publications {
-            register("publish", MavenPublication::class) {
-                from(project.components["java"])
-            }
-        }
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,22 @@
 plugins {
     id("pack.base-conventions")
+    id("pack.publish-conventions")
 }
 
 subprojects{
     plugins.apply("pack.base-conventions")
     plugins.apply("pack.publish-conventions")
     group = "org.geysermc.pack"
-    version = "3.0-SNAPSHOT"
+    version = "3.1-SNAPSHOT"
 
     java.sourceCompatibility = JavaVersion.VERSION_17
     java.targetCompatibility = JavaVersion.VERSION_17
+
+    publishing {
+        publications {
+            register("publish", MavenPublication::class) {
+                from(project.components["java"])
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,57 +1,13 @@
 plugins {
-    id("java")
-    id("java-library")
-    id("maven-publish")
-    id("com.github.johnrengelman.shadow") version "7.1.0"
-    id("io.freefair.lombok") version "6.3.0" apply false
+    id("pack.base-conventions")
 }
 
-allprojects {
-    apply(plugin = "java")
-    apply(plugin = "java-library")
-    apply(plugin = "maven-publish")
-    apply(plugin = "com.github.johnrengelman.shadow")
-    apply(plugin = "io.freefair.lombok")
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-
-        gradlePluginPortal()
-
-        // Geyser, Floodgate, Cumulus etc.
-        maven("https://repo.opencollab.dev/main")
-        maven("https://repo.opencollab.dev/maven-snapshots")
-
-        // Java pack library
-        maven("https://repo.unnamed.team/repository/unnamed-public/")
-    }
-
+subprojects{
+    plugins.apply("pack.base-conventions")
+    plugins.apply("pack.publish-conventions")
     group = "org.geysermc.pack"
     version = "3.0-SNAPSHOT"
 
     java.sourceCompatibility = JavaVersion.VERSION_17
     java.targetCompatibility = JavaVersion.VERSION_17
-
-    tasks.jar {
-        archiveClassifier.set("unshaded")
-    }
-
-    tasks.named("build") {
-        dependsOn(tasks.shadowJar)
-    }
-
-    publishing {
-        publications.create<MavenPublication>("library") {
-            artifact(tasks.shadowJar)
-        }
-        val repoName = if (version.toString().endsWith("SNAPSHOT")) "maven-snapshots" else "maven-releases"
-        repositories {
-            maven("https://repo.opencollab.dev/${repoName}/") {
-                credentials.username = System.getenv("OPENCOLLAB_USERNAME")
-                credentials.password = System.getenv("OPENCOLLAB_PASSWORD")
-                name = "opencollab"
-            }
-        }
-    }
 }

--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    application
     id("io.freefair.lombok") version "8.6"
 }
 

--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -30,11 +30,3 @@ dependencies {
 java {
     withSourcesJar()
 }
-
-publishing {
-    publications {
-        register("publish", MavenPublication::class) {
-            from(project.components["java"])
-        }
-    }
-}

--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -1,24 +1,40 @@
+plugins {
+    application
+    id("io.freefair.lombok") version "8.6"
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir("src/main/java/resources")
+        }
+    }
+}
+
 dependencies {
     api(project(":pack-schema-api"))
-    implementation("com.google.code.gson:gson:2.10.1")
-    implementation("commons-io:commons-io:2.11.0")
+    compileOnly("com.google.code.gson:gson:2.10.1")
+    compileOnly("commons-io:commons-io:2.11.0")
     implementation("com.twelvemonkeys.imageio:imageio-tga:3.9.4")
     implementation("com.nukkitx.fastutil:fastutil-int-object-maps:8.5.3")
-    implementation("net.kyori:adventure-api:4.14.0")
-    implementation("net.kyori:adventure-text-serializer-gson:4.14.0")
-    implementation("net.kyori:adventure-text-serializer-legacy:4.14.0")
-    implementation("team.unnamed:creative-api:1.7.0")
-    implementation("team.unnamed:creative-serializer-minecraft:1.7.0")
+    api("net.kyori:adventure-api:4.14.0")
+    api("net.kyori:adventure-text-serializer-gson:4.14.0")
+    api("net.kyori:adventure-text-serializer-legacy:4.14.0")
+    api("team.unnamed:creative-api:1.7.0")
+    api("team.unnamed:creative-serializer-minecraft:1.7.0")
 
     compileOnly("com.google.auto.service:auto-service:1.0.1")
     annotationProcessor("com.google.auto.service:auto-service:1.0.1")
 }
 
-tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-    from("src/main/java/resources") {
-        include("*")
-    }
+java {
+    withSourcesJar()
+}
 
-    archiveFileName.set("PackConverter-lib.jar")
-    archiveClassifier.set("")
+publishing {
+    publications {
+        register("publish", MavenPublication::class) {
+            from(project.components["java"])
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.name = "packconverter-parent"
 
 include(":bootstrap")
@@ -10,3 +12,20 @@ include(":schema-generator")
 project(":pack-schema-api").projectDir = file("pack-schema/api")
 project(":bedrock-pack-schema").projectDir = file("pack-schema/bedrock")
 project(":schema-generator").projectDir = file("pack-schema/generator")
+
+pluginManagement {
+    includeBuild("build-logic")
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+
+        // Geyser, Floodgate, Cumulus etc.
+        maven("https://repo.opencollab.dev/main")
+        maven("https://repo.opencollab.dev/maven-snapshots")
+
+        // Java pack library
+        maven("https://repo.unnamed.team/repository/unnamed-public/")
+    }
+}


### PR DESCRIPTION
This PR aims to re-work the way the pack converter library dependencies are currently published. Specifically, the library jar no longer just shades in all dependencies - which essentially forces downstream users to fully relocate it if even a single one conflicts.

Instead, this makes use of transitive dependencies, which gives users of the library a lot more adaptability. Users could for example exclude specific dependencies if need be, or bump versions of them, or, hydraulic specific: use the mod version of shadowing, jij including :p

Changes made:
- Added a build-logic module to properly apply publishing to all modules
- adds a fix to ensure shadow jars are not published to maven
- the only jar that's currently using shadow is the pack converter one; i've also made the change to only upload it in action runs (can be reverted, then we just need to figure out how to deal with differentiating between the -sources one and the "normal" one)
- bumps gradle to 8.6 to be compatible with the latest version of shadow

