### PR TITLE
Don't provide bedrock-pack-schema in the pack-schema-api artifact

### DIFF
--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -12,6 +12,7 @@ sourceSets {
 
 dependencies {
     api(project(":pack-schema-api"))
+    compileOnly(project(":bedrock-pack-schema")) // Is provided by pack-schema-api for consumers, but not for us during compile time
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("commons-io:commons-io:2.11.0")
     implementation("com.twelvemonkeys.imageio:imageio-tga:3.9.4")

--- a/pack-schema/api/build.gradle.kts
+++ b/pack-schema/api/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnlyApi(project(":bedrock-pack-schema")) // Available on compile, but not runtime classpath - we shade it in task below
+    compileOnly(project(":bedrock-pack-schema")) // Available on compile, but not runtime classpath - we shade it in task below
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("org.jetbrains:annotations:24.0.1")
 }


### PR DESCRIPTION
Don't include bedrock-pack-schema as a transitive compile time dependency in pack-schema-api