### PR TITLE
Allow `ModelStitcher.Provider` to be specified in `ModelConversionData`

### DIFF
--- a/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
@@ -26,7 +26,6 @@
 
 package org.geysermc.pack.converter;
 
-import lombok.Getter;
 import org.apache.commons.io.file.PathUtils;
 import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.converter.ActionListener;
@@ -70,7 +69,6 @@ public final class PackConverter {
     private Path tmpDir;
 
     private PackageHandler packageHandler = PackageHandler.ZIP;
-    @Getter
     private LogListener logListener = new DefaultLogListener();
 
     /**
@@ -260,9 +258,13 @@ public final class PackConverter {
             ResourcePack javaResourcePack = this.compressed ? MinecraftResourcePackReader.minecraft().readFromZipFile(this.input) : MinecraftResourcePackReader.minecraft().read(NioDirectoryFileTreeReader.read(this.input));
             BedrockResourcePack bedrockResourcePack = new BedrockResourcePack(this.tmpDir);
 
+            final Converter.ConversionDataCreationContext conversionDataCreationContext = new Converter.ConversionDataCreationContext(
+                this, logListener, input, this.tmpDir, javaResourcePack
+            );
+
             int errors = 0;
             for (Converter converter : this.converters) {
-                ConversionData data = converter.createConversionData(this, input, this.tmpDir, javaResourcePack, bedrockResourcePack);
+                ConversionData data = converter.createConversionData(conversionDataCreationContext);
                 PackConversionContext<?> context = new PackConversionContext<>(data, this, javaResourcePack, bedrockResourcePack, this.logListener);
 
                 List<ActionListener<?>> actionListeners = this.actionListeners.getOrDefault(data.getClass(), List.of());

--- a/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
@@ -26,6 +26,7 @@
 
 package org.geysermc.pack.converter;
 
+import lombok.Getter;
 import org.apache.commons.io.file.PathUtils;
 import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.converter.ActionListener;
@@ -42,7 +43,6 @@ import team.unnamed.creative.serialize.minecraft.MinecraftResourcePackReader;
 
 import javax.imageio.ImageIO;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -70,6 +70,7 @@ public final class PackConverter {
     private Path tmpDir;
 
     private PackageHandler packageHandler = PackageHandler.ZIP;
+    @Getter
     private LogListener logListener = new DefaultLogListener();
 
     /**
@@ -261,7 +262,7 @@ public final class PackConverter {
 
             int errors = 0;
             for (Converter converter : this.converters) {
-                ConversionData data = converter.createConversionData(this, input, this.tmpDir);
+                ConversionData data = converter.createConversionData(this, input, this.tmpDir, javaResourcePack, bedrockResourcePack);
                 PackConversionContext<?> context = new PackConversionContext<>(data, this, javaResourcePack, bedrockResourcePack, this.logListener);
 
                 List<ActionListener<?>> actionListeners = this.actionListeners.getOrDefault(data.getClass(), List.of());

--- a/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/PackConverter.java
@@ -153,7 +153,7 @@ public final class PackConverter {
      * @param converters the converters to add
      * @return this instance
      */
-    public PackConverter converters(@NotNull List<Converter<?>> converters) {
+    public PackConverter converters(@NotNull List<? extends Converter<?>> converters) {
         this.converters.addAll(converters);
         return this;
     }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/BaseConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/BaseConverter.java
@@ -26,16 +26,24 @@
 
 package org.geysermc.pack.converter.converter;
 
+import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.data.BaseConversionData;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.ResourcePack;
 
 import java.nio.file.Path;
 
 public abstract class BaseConverter implements Converter<BaseConversionData> {
 
     @Override
-    public BaseConversionData createConversionData(@NotNull PackConverter converter, @NotNull Path inputDirectory, @NotNull Path outputDirectory) {
+    public BaseConversionData createConversionData(
+        @NotNull PackConverter converter,
+        @NotNull Path inputDirectory,
+        @NotNull Path outputDirectory,
+        @NotNull ResourcePack javaResourcePack,
+        @NotNull BedrockResourcePack bedrockResourcePack
+    ) {
         return new BaseConversionData(inputDirectory, outputDirectory);
     }
 }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/BaseConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/BaseConverter.java
@@ -26,24 +26,13 @@
 
 package org.geysermc.pack.converter.converter;
 
-import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
-import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.data.BaseConversionData;
 import org.jetbrains.annotations.NotNull;
-import team.unnamed.creative.ResourcePack;
-
-import java.nio.file.Path;
 
 public abstract class BaseConverter implements Converter<BaseConversionData> {
 
     @Override
-    public BaseConversionData createConversionData(
-        @NotNull PackConverter converter,
-        @NotNull Path inputDirectory,
-        @NotNull Path outputDirectory,
-        @NotNull ResourcePack javaResourcePack,
-        @NotNull BedrockResourcePack bedrockResourcePack
-    ) {
-        return new BaseConversionData(inputDirectory, outputDirectory);
+    public BaseConversionData createConversionData(@NotNull ConversionDataCreationContext context) {
+        return new BaseConversionData(context.inputDirectory(), context.outputDirectory());
     }
 }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/Converter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/Converter.java
@@ -26,10 +26,10 @@
 
 package org.geysermc.pack.converter.converter;
 
-import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.PackConversionContext;
 import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.data.ConversionData;
+import org.geysermc.pack.converter.util.LogListener;
 import org.jetbrains.annotations.NotNull;
 import team.unnamed.creative.ResourcePack;
 
@@ -39,15 +39,18 @@ public interface Converter<T extends ConversionData> {
 
     void convert(@NotNull PackConversionContext<T> context) throws Exception;
 
-    T createConversionData(
-        @NotNull PackConverter converter,
-        @NotNull Path inputDirectory,
-        @NotNull Path outputDirectory,
-        @NotNull ResourcePack javaResourcePack,
-        @NotNull BedrockResourcePack bedrockResourcePack
-    );
+    T createConversionData(@NotNull ConversionDataCreationContext context);
 
     default boolean isExperimental() {
         return false;
+    }
+
+    record ConversionDataCreationContext(
+        @NotNull PackConverter converter,
+        @NotNull LogListener logListener,
+        @NotNull Path inputDirectory,
+        @NotNull Path outputDirectory,
+        @NotNull ResourcePack javaResourcePack
+    ) {
     }
 }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/Converter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/Converter.java
@@ -26,10 +26,12 @@
 
 package org.geysermc.pack.converter.converter;
 
+import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.PackConversionContext;
 import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.data.ConversionData;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.ResourcePack;
 
 import java.nio.file.Path;
 
@@ -37,7 +39,13 @@ public interface Converter<T extends ConversionData> {
 
     void convert(@NotNull PackConversionContext<T> context) throws Exception;
 
-    T createConversionData(@NotNull PackConverter converter, @NotNull Path inputDirectory, @NotNull Path outputDirectory);
+    T createConversionData(
+        @NotNull PackConverter converter,
+        @NotNull Path inputDirectory,
+        @NotNull Path outputDirectory,
+        @NotNull ResourcePack javaResourcePack,
+        @NotNull BedrockResourcePack bedrockResourcePack
+    );
 
     default boolean isExperimental() {
         return false;

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/Converters.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/Converters.java
@@ -31,14 +31,14 @@ import java.util.ServiceLoader;
 
 public class Converters {
 
-    public static List<Converter<?>> defaultConverters() {
+    public static List<? extends Converter<?>> defaultConverters() {
         return defaultConverters(false);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static List<Converter<?>> defaultConverters(boolean experimental) {
-        return (List) ServiceLoader.load(Converter.class).stream()
+    public static List<? extends Converter<?>> defaultConverters(boolean experimental) {
+        return ServiceLoader.load(Converter.class).stream()
                 .map(ServiceLoader.Provider::get)
+                .map(c -> (Converter<?>)c)
                 .filter(converter -> experimental || !converter.isExperimental())
                 .toList();
     }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/model/ModelConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/model/ModelConverter.java
@@ -184,8 +184,17 @@ public class ModelConverter implements Converter<ModelConversionData> {
     }
 
     @Override
-    public ModelConversionData createConversionData(@NotNull PackConverter converter, @NotNull Path inputDirectory, @NotNull Path outputDirectory) {
-        return new ModelConversionData(inputDirectory, outputDirectory);
+    public ModelConversionData createConversionData(
+        @NotNull PackConverter converter,
+        @NotNull Path inputDirectory,
+        @NotNull Path outputDirectory,
+        @NotNull ResourcePack javaResourcePack,
+        @NotNull BedrockResourcePack bedrockResourcePack
+    ) {
+        return new ModelConversionData(
+            inputDirectory, outputDirectory,
+            ModelStitcher.vanillaProvider(javaResourcePack, converter.getLogListener())
+        );
     }
 
     private TextureUV multiplyUv(TextureUV textureUV, float mult) {

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/model/ModelConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/model/ModelConverter.java
@@ -42,7 +42,6 @@ import org.geysermc.pack.bedrock.resource.models.entity.modelentity.geometry.bon
 import org.geysermc.pack.bedrock.resource.models.entity.modelentity.geometry.bones.cubes.uv.Up;
 import org.geysermc.pack.bedrock.resource.models.entity.modelentity.geometry.bones.cubes.uv.West;
 import org.geysermc.pack.converter.PackConversionContext;
-import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.converter.Converter;
 import org.geysermc.pack.converter.data.ModelConversionData;
 import org.jetbrains.annotations.NotNull;
@@ -54,7 +53,6 @@ import team.unnamed.creative.model.ElementRotation;
 import team.unnamed.creative.model.Model;
 import team.unnamed.creative.texture.TextureUV;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -184,16 +182,10 @@ public class ModelConverter implements Converter<ModelConversionData> {
     }
 
     @Override
-    public ModelConversionData createConversionData(
-        @NotNull PackConverter converter,
-        @NotNull Path inputDirectory,
-        @NotNull Path outputDirectory,
-        @NotNull ResourcePack javaResourcePack,
-        @NotNull BedrockResourcePack bedrockResourcePack
-    ) {
+    public ModelConversionData createConversionData(@NotNull ConversionDataCreationContext context) {
         return new ModelConversionData(
-            inputDirectory, outputDirectory,
-            ModelStitcher.vanillaProvider(javaResourcePack, converter.getLogListener())
+            context.inputDirectory(), context.outputDirectory(),
+            ModelStitcher.vanillaProvider(context.javaResourcePack(), context.logListener())
         );
     }
 

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
@@ -27,6 +27,7 @@
 package org.geysermc.pack.converter.converter.texture;
 
 import com.google.auto.service.AutoService;
+import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.PackConversionContext;
 import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.converter.Converter;
@@ -36,6 +37,7 @@ import org.geysermc.pack.converter.converter.texture.transformer.TransformedText
 import org.geysermc.pack.converter.data.TextureConversionData;
 import org.geysermc.pack.converter.util.ImageUtil;
 import org.jetbrains.annotations.NotNull;
+import team.unnamed.creative.ResourcePack;
 import team.unnamed.creative.texture.Texture;
 
 import javax.imageio.ImageIO;
@@ -147,7 +149,13 @@ public class TextureConverter implements Converter<TextureConversionData> {
     }
 
     @Override
-    public TextureConversionData createConversionData(@NotNull PackConverter converter, @NotNull Path inputDirectory, @NotNull Path outputDirectory) {
+    public TextureConversionData createConversionData(
+        @NotNull PackConverter converter,
+        @NotNull Path inputDirectory,
+        @NotNull Path outputDirectory,
+        @NotNull ResourcePack javaResourcePack,
+        @NotNull BedrockResourcePack bedrockResourcePack
+    ) {
         return new TextureConversionData(inputDirectory, outputDirectory, converter.textureSubdirectory());
     }
 }

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
@@ -38,7 +38,8 @@ import org.jetbrains.annotations.NotNull;
 import team.unnamed.creative.texture.Texture;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.AlphaComposite;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/converter/texture/TextureConverter.java
@@ -27,9 +27,7 @@
 package org.geysermc.pack.converter.converter.texture;
 
 import com.google.auto.service.AutoService;
-import org.geysermc.pack.bedrock.resource.BedrockResourcePack;
 import org.geysermc.pack.converter.PackConversionContext;
-import org.geysermc.pack.converter.PackConverter;
 import org.geysermc.pack.converter.converter.Converter;
 import org.geysermc.pack.converter.converter.texture.transformer.TextureTransformer;
 import org.geysermc.pack.converter.converter.texture.transformer.TransformContext;
@@ -37,12 +35,10 @@ import org.geysermc.pack.converter.converter.texture.transformer.TransformedText
 import org.geysermc.pack.converter.data.TextureConversionData;
 import org.geysermc.pack.converter.util.ImageUtil;
 import org.jetbrains.annotations.NotNull;
-import team.unnamed.creative.ResourcePack;
 import team.unnamed.creative.texture.Texture;
 
 import javax.imageio.ImageIO;
-import java.awt.AlphaComposite;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -149,13 +145,7 @@ public class TextureConverter implements Converter<TextureConversionData> {
     }
 
     @Override
-    public TextureConversionData createConversionData(
-        @NotNull PackConverter converter,
-        @NotNull Path inputDirectory,
-        @NotNull Path outputDirectory,
-        @NotNull ResourcePack javaResourcePack,
-        @NotNull BedrockResourcePack bedrockResourcePack
-    ) {
-        return new TextureConversionData(inputDirectory, outputDirectory, converter.textureSubdirectory());
+    public TextureConversionData createConversionData(@NotNull ConversionDataCreationContext context) {
+        return new TextureConversionData(context.inputDirectory(), context.outputDirectory(), context.converter().textureSubdirectory());
     }
 }

--- a/converter/src/main/java/org/geysermc/pack/converter/data/ModelConversionData.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/data/ModelConversionData.java
@@ -26,7 +26,9 @@
 
 package org.geysermc.pack.converter.data;
 
+import lombok.Getter;
 import net.kyori.adventure.key.Key;
+import org.geysermc.pack.converter.converter.model.ModelStitcher;
 import org.jetbrains.annotations.NotNull;
 import team.unnamed.creative.model.Model;
 
@@ -36,9 +38,12 @@ import java.util.Map;
 
 public class ModelConversionData extends BaseConversionData {
     private final Map<Key, Model> stitchedModels = new HashMap<>();
+    @Getter
+    private final ModelStitcher.Provider modelProvider;
 
-    public ModelConversionData(@NotNull Path inputDirectory, @NotNull Path outputDirectory) {
+    public ModelConversionData(@NotNull Path inputDirectory, @NotNull Path outputDirectory, ModelStitcher.Provider modelProvider) {
         super(inputDirectory, outputDirectory);
+        this.modelProvider = modelProvider;
     }
 
     public void addStitchedModel(@NotNull Model model) {


### PR DESCRIPTION
This allows Hydraulic to allow other mods to provide models. This PR also fixes some generics in `Converters`.