### PR TITLE
Allow converting item models manually

### DIFF
--- a/converter/src/main/java/org/geysermc/pack/converter/type/model/ModelConverter.java
+++ b/converter/src/main/java/org/geysermc/pack/converter/type/model/ModelConverter.java
@@ -59,8 +59,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class ModelConverter implements AssetExtractor<Model>, AssetConverter<Model, BedrockModel>, AssetCombiner<BedrockModel> {
-    public static final ModelConverter INSTANCE = new ModelConverter();
+public record ModelConverter(boolean convertItemModels) implements AssetExtractor<Model>, AssetConverter<Model, BedrockModel>, AssetCombiner<BedrockModel> {
+    public static final ModelConverter INSTANCE = new ModelConverter(false);
 
     private static final String FORMAT_VERSION = "1.16.0";
     private static final String GEOMETRY_FORMAT = "geometry.%s";
@@ -90,7 +90,7 @@ public class ModelConverter implements AssetExtractor<Model>, AssetConverter<Mod
         context.debug("Converting model " + model.key().key() + ":" + value);
 
         // TODO: Convert item models but save differently?
-        if (value.startsWith("item/")) {
+        if (value.startsWith("item/") && !convertItemModels) {
             return null;
         }
 


### PR DESCRIPTION
This PR adds a field to `ModelConverter` to tell it to convert models from the `item` directory. PackConverter by default doesn't do this as bedrock's items don't have custom models that are as extensive as Java's, so there's no good place to put converted item models from Java. However, library users may still want item models converted manually.

The proper way to do this is to find out where to store item models and generate item attachables along with those models as well. This will be done in a later PR.